### PR TITLE
Merge Full Text Incremental Updates for Partial Tables

### DIFF
--- a/java/data_client/src/main/java/edu/harvard/data/DataConfig.java
+++ b/java/data_client/src/main/java/edu/harvard/data/DataConfig.java
@@ -101,6 +101,7 @@ public class DataConfig {
   private final String emrTaskBidPrice;
   private final String emrMaximumRetries;
   private final String emrAvailabilityZoneGroup;
+  private final String emrConfiguration;
 
   private final String phase0InstanceType;
   private final String phase0BidPrice;
@@ -217,6 +218,7 @@ public class DataConfig {
     this.emrCoreInstanceCount = getConfigParameter("emr_core_instance_count", verify);
     this.emrTaskInstanceCount = getConfigParameter("emr_task_instance_count", verify);
     this.emrAvailabilityZoneGroup = getConfigParameter("emr_availability_zone_group", verify);
+    this.emrConfiguration = getConfigParameter("emr_configuration", verify);
 
     this.phase0InstanceType = getConfigParameter("phase_0_instance_type", verify);
     this.phase0BidPrice = getConfigParameter("phase_0_bid_price", verify);
@@ -619,6 +621,10 @@ public class DataConfig {
     return emrAvailabilityZoneGroup;
   }
 
+  public String getEmrConfiguration() {
+	  return emrConfiguration;
+  }
+  
   public String getLeaseDynamoTable() {
     return leaseDynamoTable;
   }

--- a/java/data_client/src/main/java/edu/harvard/data/DataConfig.java
+++ b/java/data_client/src/main/java/edu/harvard/data/DataConfig.java
@@ -150,7 +150,7 @@ public class DataConfig {
     this.identityRedshiftSchema = "pii";
     this.emrCodeDir = "/home/hadoop/code";
     this.emrLogDir = "/home/hadoop";
-    this.fullTextDir = "/home/hadoop/full_text";
+    this.fullTextDir = "/tmp/full_text";
     this.hdfsBase = "/phase_";
     this.hdfsVerifyBase = "/verify" + this.hdfsBase;
     this.ec2GitDir = "/home/ec2-user/harvard-data-tools";

--- a/java/data_client/src/main/java/edu/harvard/data/DataConfig.java
+++ b/java/data_client/src/main/java/edu/harvard/data/DataConfig.java
@@ -376,6 +376,10 @@ public class DataConfig {
   public String getEmrLogFile(final String stepId) {
     return emrLogDir + "/" + stepId + ".out";
   }
+  
+  public String getEmrLogDir() {
+	return emrLogDir;
+  }
 
   public String getDatasetName() {
     return datasetName;

--- a/java/data_client/src/main/java/edu/harvard/data/DataConfig.java
+++ b/java/data_client/src/main/java/edu/harvard/data/DataConfig.java
@@ -44,6 +44,7 @@ public class DataConfig {
   private final IdentifierType mainIdentifier;
   private final String serverTimezone;
   private final FormatLibrary.Format pipelineFormat;
+  private final FormatLibrary.Format fulltextFormat;
 
   private final String dataPipelineRole;
   private final String dataPipelineResourceRoleArn;
@@ -165,6 +166,7 @@ public class DataConfig {
     this.dataSource = getConfigParameter("data_source", verify);
     this.datasetName = getConfigParameter("dataset_name", verify);
     this.pipelineFormat = Format.fromLabel(getConfigParameter("pipeline_format", verify));
+    this.fulltextFormat = Format.fromLabel(getConfigParameter("fulltext_format", verify));
     this.dataPipelineRole = getConfigParameter("data_pipeline_role", verify);
     this.dataPipelineResourceRoleArn = getConfigParameter("data_pipeline_resource_role_arn",
         verify);
@@ -644,6 +646,10 @@ public class DataConfig {
   public FormatLibrary.Format getPipelineFormat() {
     return pipelineFormat;
   }
+
+  public FormatLibrary.Format getFulltextFormat() {
+	    return fulltextFormat;
+  }  
 
   public String getHdtMonitorUrl() {
     return hdtMonitorUrl;

--- a/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
+++ b/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
@@ -97,7 +97,7 @@ public class FormatLibrary {
   private static final CSVFormat CANVAS_CSV_FORMAT = CSVFormat.TDF.withQuote(null)
       .withNullString("\\N").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);
 
-  private static final CSVFormat INTERNAL_CSV_FORMAT = CSVFormat.TDF.withQuote('"')
+  private static final CSVFormat INTERNAL_CSV_FORMAT = CSVFormat.TDF.withQuote('"').withEscape(null)
       .withNullString("\\N").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);
 
   private static final CSVFormat INTERNAL_SIS_FORMAT = CSVFormat.TDF.withQuote(null).withEscape('/')

--- a/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
+++ b/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
@@ -101,8 +101,8 @@ public class FormatLibrary {
   private static final CSVFormat CANVAS_CSV_FORMAT = CSVFormat.TDF.withQuote(null)
       .withNullString("\\N").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);
 
-  private static final CSVFormat INTERNAL_CSV_FORMAT = CSVFormat.TDF.withQuote('"')
-      .withNullString("\\N").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);
+  private static final CSVFormat INTERNAL_CSV_FORMAT = CSVFormat.TDF.withQuote(null).withEscape('/')
+	      .withNullString("\\N").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);
 
   private static final CSVFormat INTERNAL_SIS_FORMAT = CSVFormat.TDF.withQuote(null).withEscape('/')
 	      .withNullString("null").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);  

--- a/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
+++ b/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
@@ -97,7 +97,7 @@ public class FormatLibrary {
   private static final CSVFormat CANVAS_CSV_FORMAT = CSVFormat.TDF.withQuote(null)
       .withNullString("\\N").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);
 
-  private static final CSVFormat INTERNAL_CSV_FORMAT = CSVFormat.TDF.withQuote('"').withEscape('\')
+  private static final CSVFormat INTERNAL_CSV_FORMAT = CSVFormat.TDF.withQuote('"').withEscape('\\')
       .withNullString("\\N").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);
 
   private static final CSVFormat INTERNAL_SIS_FORMAT = CSVFormat.TDF.withQuote(null).withEscape('/')

--- a/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
+++ b/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
@@ -97,7 +97,7 @@ public class FormatLibrary {
   private static final CSVFormat CANVAS_CSV_FORMAT = CSVFormat.TDF.withQuote(null)
       .withNullString("\\N").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);
 
-  private static final CSVFormat INTERNAL_CSV_FORMAT = CSVFormat.TDF.withQuote('"').withEscape('\\')
+  private static final CSVFormat INTERNAL_CSV_FORMAT = CSVFormat.TDF.withQuote('"')
       .withNullString("\\N").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);
 
   private static final CSVFormat INTERNAL_SIS_FORMAT = CSVFormat.TDF.withQuote(null).withEscape('/')

--- a/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
+++ b/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
@@ -97,7 +97,7 @@ public class FormatLibrary {
   private static final CSVFormat CANVAS_CSV_FORMAT = CSVFormat.TDF.withQuote(null)
       .withNullString("\\N").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);
 
-  private static final CSVFormat INTERNAL_CSV_FORMAT = CSVFormat.TDF.withQuote('"').withEscape(null)
+  private static final CSVFormat INTERNAL_CSV_FORMAT = CSVFormat.TDF.withQuote('"').withEscape('\\')
       .withNullString("\\N").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);
 
   private static final CSVFormat INTERNAL_SIS_FORMAT = CSVFormat.TDF.withQuote(null).withEscape('/')

--- a/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
+++ b/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
@@ -94,10 +94,10 @@ public class FormatLibrary {
   public static final String LOCAL_DATE_FORMAT_STRING = "yyyy-MM-dd Z";
   public static final String JSON_DATE_FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ssZ";
 
-  private static final CSVFormat CANVAS_CSV_FORMAT = CSVFormat.TDF.withQuote(null).withEscape('/')
+  private static final CSVFormat CANVAS_CSV_FORMAT = CSVFormat.TDF.withQuote(null)
       .withNullString("\\N").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);
 
-  private static final CSVFormat INTERNAL_CSV_FORMAT = CSVFormat.TDF.withQuote(null).withEscape('/')
+  private static final CSVFormat INTERNAL_CSV_FORMAT = CSVFormat.TDF.withQuote(null)
       .withNullString("\\N").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);
 
   private static final CSVFormat INTERNAL_SIS_FORMAT = CSVFormat.TDF.withQuote(null).withEscape('/')

--- a/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
+++ b/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
@@ -97,7 +97,7 @@ public class FormatLibrary {
   private static final CSVFormat CANVAS_CSV_FORMAT = CSVFormat.TDF.withQuote(null)
       .withNullString("\\N").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);
 
-  private static final CSVFormat INTERNAL_CSV_FORMAT = CSVFormat.TDF.withQuote('"').withEscape('\\')
+  private static final CSVFormat INTERNAL_CSV_FORMAT = CSVFormat.TDF.withQuote('"').withEscape('\')
       .withNullString("\\N").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);
 
   private static final CSVFormat INTERNAL_SIS_FORMAT = CSVFormat.TDF.withQuote(null).withEscape('/')

--- a/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
+++ b/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
@@ -97,7 +97,7 @@ public class FormatLibrary {
   private static final CSVFormat CANVAS_CSV_FORMAT = CSVFormat.TDF.withQuote(null)
       .withNullString("\\N").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);
 
-  private static final CSVFormat INTERNAL_CSV_FORMAT = CSVFormat.TDF.withQuote(null)
+  private static final CSVFormat INTERNAL_CSV_FORMAT = CSVFormat.TDF.withQuote('"')
       .withNullString("\\N").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);
 
   private static final CSVFormat INTERNAL_SIS_FORMAT = CSVFormat.TDF.withQuote(null).withEscape('/')

--- a/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
+++ b/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
@@ -11,7 +11,7 @@ public class FormatLibrary {
             "matterhorn"), DecompressedMatterhorn("decompressed_matterhorn"), CompressedInternal(
                 "compressed_internal"), DecompressedInternal("decompressed_internal"), Mediasites(
                     "mediasites"), DecompressedMediasites("decompressed_mediasites"), Sis(
-                    		"sis"), DecompressedSis("decompressed_sis");
+                    		"sis"), DecompressedSis("decompressed_sis"), DecompressedRest("decompressed_rest");
 
     private final String label;
 
@@ -49,6 +49,8 @@ public class FormatLibrary {
         return CompressedInternal;
       case "decompressed_internal":
         return DecompressedInternal;
+      case "decompressed_rest":
+          return DecompressedRest;        
       default:
         return Format.valueOf(label);
       }
@@ -81,6 +83,8 @@ public class FormatLibrary {
       return createCompressedInternalFormat();
     case DecompressedInternal:
       return createDecompressedInternalFormat();
+    case DecompressedRest:
+        return createDecompressedRestFormat();
     default:
       throw new RuntimeException("Unknown format " + format);
     }
@@ -102,6 +106,9 @@ public class FormatLibrary {
 
   private static final CSVFormat INTERNAL_SIS_FORMAT = CSVFormat.TDF.withQuote(null).withEscape('/')
 	      .withNullString("null").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);  
+ 
+  private static final CSVFormat INTERNAL_TDF_FORMAT = CSVFormat.TDF.withQuote('"')
+	      .withNullString("\\N").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);  
   
   private static final String CANVAS_FILE_ENCODING = "UTF-8";
   private static final String MATTERHORN_FILE_ENCODING = "UTF-8";
@@ -235,4 +242,15 @@ public class FormatLibrary {
     return format;
   }
 
+  private TableFormat createDecompressedRestFormat() {
+	    final TableFormat format = new TableFormat(Format.DecompressedRest);
+	    format.setTimestampFormat(new SimpleDateFormat(CANVAS_TIMESTAMP_FORMAT_STRING));
+	    format.setDateFormat(new SimpleDateFormat(CANVAS_DATE_FORMAT_STRING));
+	    format.setIncludeHeaders(false);
+	    format.setEncoding(CANVAS_FILE_ENCODING);
+	    format.setCsvFormat(INTERNAL_TDF_FORMAT);
+	    format.setCompression(TableFormat.Compression.None);
+	    return format;
+  }  
+  
 }

--- a/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
+++ b/java/data_client/src/main/java/edu/harvard/data/FormatLibrary.java
@@ -94,7 +94,7 @@ public class FormatLibrary {
   public static final String LOCAL_DATE_FORMAT_STRING = "yyyy-MM-dd Z";
   public static final String JSON_DATE_FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ssZ";
 
-  private static final CSVFormat CANVAS_CSV_FORMAT = CSVFormat.TDF.withQuote(null)
+  private static final CSVFormat CANVAS_CSV_FORMAT = CSVFormat.TDF.withQuote(null).withEscape('/')
       .withNullString("\\N").withRecordSeparator("\n").withIgnoreSurroundingSpaces(false);
 
   private static final CSVFormat INTERNAL_CSV_FORMAT = CSVFormat.TDF.withQuote(null).withEscape('/')

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CodeGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CodeGenerator.java
@@ -227,7 +227,7 @@ public abstract class CodeGenerator {
       new S3ToHdfsManifestGenerator(codeDir, config, dataIndex).generate();
 
       log.info("Generating Hive table definitions in " + codeDir);
-      new CreateHiveTableGenerator(codeDir, spec, FullTextSchema.read(getFullTextResource() )).generate();
+      new CreateHiveTableGenerator(codeDir, config, spec, FullTextSchema.read(getFullTextResource() )).generate();
 
       log.info("Generating Hive query manifests in " + codeDir);
       new HiveQueryManifestGenerator(codeDir, spec).generate();

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CodeGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CodeGenerator.java
@@ -227,7 +227,7 @@ public abstract class CodeGenerator {
       new S3ToHdfsManifestGenerator(codeDir, config, dataIndex).generate();
 
       log.info("Generating Hive table definitions in " + codeDir);
-      new CreateHiveTableGenerator(codeDir, spec).generate();
+      new CreateHiveTableGenerator(codeDir, spec, FullTextSchema.read(getFullTextResource() )).generate();
 
       log.info("Generating Hive query manifests in " + codeDir);
       new HiveQueryManifestGenerator(codeDir, spec).generate();

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CodeGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CodeGenerator.java
@@ -233,7 +233,7 @@ public abstract class CodeGenerator {
       new HiveQueryManifestGenerator(codeDir, spec).generate();
 
       log.info("Generating Redshift copy from S3 script in " + codeDir);
-      new S3ToRedshiftLoaderGenerator(codeDir, spec, config, workingDir, dataIndex, IdentitySchema.read(getIdentifierResource())).generate();
+      new S3ToRedshiftLoaderGenerator(codeDir, spec, config, workingDir, dataIndex, IdentitySchema.read(getIdentifierResource()), FullTextSchema.read(getFullTextResource())).generate();
 
       log.info("Generating move unmodified files script in " + codeDir);
       new MoveUnmodifiedTableGenerator(codeDir, spec).generate();

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
@@ -165,7 +165,7 @@ public class CreateHiveTableGenerator {
     listFields(out, table, table.getListofColumns(), addMetadata );
     out.println("    )");
     //out.println("    ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t' LINES TERMINATED By '\\n'");
-    addRowFormat(out, isQuotedFormat);
+    addRowFormat(out, false);
     out.println("    STORED AS TEXTFILE");
     out.println("    LOCATION '" + locationVar + "/" + table.getTableName() + "/';");
     out.println();
@@ -188,7 +188,7 @@ public class CreateHiveTableGenerator {
 	listFields(out, table, textfieldsonly, addMetadata );
 	out.println("    )");
 	//out.println("    ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t' LINES TERMINATED By '\\n'");
-	addRowFormat(out, isQuotedFormat);
+	addRowFormat(out, false);
 	out.println("    STORED AS TEXTFILE");
 	out.println("    LOCATION '" + locationVar + "/" + table.getTableName() + "/';");
 	out.println();

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
@@ -157,7 +157,8 @@ public class CreateHiveTableGenerator {
     out.println("  CREATE EXTERNAL TABLE " + tableName + " (");
     listFields(out, table, table.getListofColumns(), addMetadata );
     out.println("    )");
-    out.println("    ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t' LINES TERMINATED By '\\n'");
+    //out.println("    ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t' LINES TERMINATED By '\\n'");
+    addRowFormat(out, true);
     out.println("    STORED AS TEXTFILE");
     out.println("    LOCATION '" + locationVar + "/" + table.getTableName() + "/';");
     out.println();
@@ -173,7 +174,8 @@ public class CreateHiveTableGenerator {
 	out.println("  CREATE EXTERNAL TABLE " + tableName + " (");
 	listFields(out, table, textfieldsonly, addMetadata );
 	out.println("    )");
-	out.println("    ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t' LINES TERMINATED By '\\n'");
+	//out.println("    ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t' LINES TERMINATED By '\\n'");
+	addRowFormat(out, true);
 	out.println("    STORED AS TEXTFILE");
 	out.println("    LOCATION '" + locationVar + "/" + table.getTableName() + "/';");
 	out.println();
@@ -243,6 +245,18 @@ public class CreateHiveTableGenerator {
 	} else {
 	    	return ("    " + columnName + " " + columnType);
 	}
+  }
+  
+  private void addRowFormat( final PrintStream out, final boolean quotedFields ) {
+	  if (quotedFields) {
+		  out.println("    ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.OpenCSVSerde'");
+		  out.println("    WITH SERDEPROPERTIES (");
+		  out.println("       'separatorChar' = '\\t',");
+		  out.println("       'escapeChars' = '\\'");
+		  out.println("    )");
+	  } else {
+		  out.println("    ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t' LINES TERMINATED By '\\n'");
+	  }
   }
   
 }

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
@@ -165,7 +165,7 @@ public class CreateHiveTableGenerator {
     listFields(out, table, table.getListofColumns(), addMetadata );
     out.println("    )");
     //out.println("    ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t' LINES TERMINATED By '\\n'");
-    addRowFormat(out, isQuotedFormat);
+    addRowFormat(out, false );
     out.println("    STORED AS TEXTFILE");
     out.println("    LOCATION '" + locationVar + "/" + table.getTableName() + "/';");
     out.println();
@@ -188,7 +188,7 @@ public class CreateHiveTableGenerator {
 	listFields(out, table, textfieldsonly, addMetadata );
 	out.println("    )");
 	//out.println("    ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t' LINES TERMINATED By '\\n'");
-	addRowFormat(out, isQuotedFormat);
+	addRowFormat(out, false );
 	out.println("    STORED AS TEXTFILE");
 	out.println("    LOCATION '" + locationVar + "/" + table.getTableName() + "/';");
 	out.println();

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
@@ -158,6 +158,7 @@ public class CreateHiveTableGenerator {
 	      final DataSchemaTable table, final String logFile ) {
 	final FullTextTable fulltexttable = textSchema.get( table.getTableName() );
 	final List<String> textfieldsonly = fulltexttable.getColumns();
+	textfieldsonly.add(0, fulltexttable.getKey());
 	out.println("sudo hive -e \"");	
 	out.println("  CREATE EXTERNAL TABLE " + tableName + " (");
 	listFields(out, table, textfieldsonly );

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
@@ -157,7 +157,6 @@ public class CreateHiveTableGenerator {
 	      final DataSchemaTable table, final String logFile ) {
 	final FullTextTable fulltexttable = textSchema.get( table.getTableName() );
 	final List<String> textfieldsonly = fulltexttable.getColumns();
-	textfieldsonly.add(0, fulltexttable.getKey());
 	out.println("sudo hive -e \"");	
 	out.println("  CREATE EXTERNAL TABLE " + tableName + " (");
 	listFields(out, table, textfieldsonly );

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
@@ -265,8 +265,8 @@ public class CreateHiveTableGenerator {
 	  if (quotedFields) {
 		  out.println("    ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.OpenCSVSerde'");
 		  out.println("    WITH SERDEPROPERTIES (");
-		  out.println("       'separatorChar' = '\\t',");
-		  out.println("       'escapeChars' = '\\\\'");
+		  out.println("       'separatorChar' = '\\\\t',");
+		  out.println("       'escapeChar' = '\\\\\\\\'");
 		  out.println("    )");
 	  } else {
 		  out.println("    ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t' LINES TERMINATED By '\\n'");

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
@@ -266,7 +266,7 @@ public class CreateHiveTableGenerator {
 		  out.println("    ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.OpenCSVSerde'");
 		  out.println("    WITH SERDEPROPERTIES (");
 		  out.println("       'separatorChar' = '\\t',");
-		  out.println("       'escapeChars' = '\\'");
+		  out.println("       'escapeChars' = '\\\\'");
 		  out.println("    )");
 	  } else {
 		  out.println("    ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t' LINES TERMINATED By '\\n'");

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
@@ -165,7 +165,7 @@ public class CreateHiveTableGenerator {
     listFields(out, table, table.getListofColumns(), addMetadata );
     out.println("    )");
     //out.println("    ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t' LINES TERMINATED By '\\n'");
-    addRowFormat(out, false);
+    addRowFormat(out, isQuotedFormat);
     out.println("    STORED AS TEXTFILE");
     out.println("    LOCATION '" + locationVar + "/" + table.getTableName() + "/';");
     out.println();
@@ -188,7 +188,7 @@ public class CreateHiveTableGenerator {
 	listFields(out, table, textfieldsonly, addMetadata );
 	out.println("    )");
 	//out.println("    ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t' LINES TERMINATED By '\\n'");
-	addRowFormat(out, false);
+	addRowFormat(out, isQuotedFormat);
 	out.println("    STORED AS TEXTFILE");
 	out.println("    LOCATION '" + locationVar + "/" + table.getTableName() + "/';");
 	out.println();

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
@@ -51,7 +51,7 @@ public class CreateHiveTableGenerator {
         log.info("Creating Hive " + phaseFile + " file in " + dir);
         
         generateCreateTablesFile(out, i + 1, schemaVersions.getPhase(i), schemaVersions.getPhase(i + 1),
-           config.getFullTextDir() + "/" + fileBase + ".out");
+           config.getEmrLogDir() + "/" + fileBase + ".out");
       }
     }
   }
@@ -99,6 +99,8 @@ public class CreateHiveTableGenerator {
 	                    generateCopyStatement(out, tableName, table );
 	                    createTable( out, tableName, table, "/current", logFile, addMetadata );
 	            	    out.println();
+	                } else {
+	                	out.println("echo \"Full text table for " + table.getTableName() + " does not exist.\"" + logFile + " 2>&1");
 	                }
 	            }
 	        }

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
@@ -85,7 +85,7 @@ public class CreateHiveTableGenerator {
 	                createTableTransactional( out, tableName, table );
 	                out.println("\" &> " + logFile);
 	            } else {
-	        	    out.println("hadoop fs -mkdir /current" + "; fi");
+	        	    out.println("hadoop fs -mkdir /current" + "/" + table.getTableName() );
 	                out.println("hive -e \"");
 	                createTable( out, tableName, table, "/current" + "/" + table.getTableName() );
 	                out.println("\" &> " + logFile);
@@ -95,7 +95,7 @@ public class CreateHiveTableGenerator {
 	    }
 	  }
 	}
-	out.println("; fi");
+	out.println("fi");
 	out.println();
   }
 

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
@@ -159,7 +159,7 @@ public class CreateHiveTableGenerator {
 	final List<String> textfieldsonly = fulltexttable.getColumns();
 	textfieldsonly.add(0, fulltexttable.getKey());
 	out.println("sudo hive -e \"");	
-	out.println("  CREATE EXTERNAL TABLE " + tableName + " (");
+	out.println("  CREATE TABLE " + tableName + " (");
 	listFields(out, table, textfieldsonly );
 	out.println("    )");
 	out.println("    COMMENT 'Latest comprehensive output data merging current + historical'");

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
@@ -156,7 +156,7 @@ public class CreateHiveTableGenerator {
       final DataSchemaTable table, final String locationVar, final String logFile, final boolean addMetadata ) {
 
       final FormatLibrary formatLibrary = new FormatLibrary();
-      final boolean isQuotedFormat = formatLibrary.getFormat(config.getPipelineFormat())
+      final boolean isQuotedFormat = formatLibrary.getFormat(config.getFulltextFormat())
 						  .getCsvFormat()
 						  .isQuoteCharacterSet();
 	  
@@ -176,7 +176,7 @@ public class CreateHiveTableGenerator {
 	      final DataSchemaTable table, final String locationVar, final String logFile, final boolean addMetadata ) {
 	
 	final FormatLibrary formatLibrary = new FormatLibrary();
-	final boolean isQuotedFormat = formatLibrary.getFormat(config.getPipelineFormat())
+	final boolean isQuotedFormat = formatLibrary.getFormat(config.getFulltextFormat())
 						    .getCsvFormat()
 						    .isQuoteCharacterSet();
 	

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
@@ -157,6 +157,7 @@ public class CreateHiveTableGenerator {
 	      final DataSchemaTable table, final String logFile ) {
 	final FullTextTable fulltexttable = textSchema.get( table.getTableName() );
 	final List<String> textfieldsonly = fulltexttable.getColumns();
+	textfieldsonly.add(0, fulltexttable.getKey());
 	out.println("sudo hive -e \"");	
 	out.println("  CREATE EXTERNAL TABLE " + tableName + " (");
 	listFields(out, table, textfieldsonly );

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
@@ -100,7 +100,7 @@ public class CreateHiveTableGenerator {
 	                    createTable( out, tableName, table, "/current", logFile, addMetadata );
 	            	    out.println();
 	                } else {
-	                	out.println("echo \"Full text table for " + table.getTableName() + " does not exist.\"" + logFile + " 2>&1");
+	                	out.println("echo \"Full text table for " + table.getTableName() + " does not exist.\"" + " >> " + logFile + " 2>&1");
 	                }
 	            }
 	        }

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -193,6 +194,9 @@ public class CreateHiveTableGenerator {
   private void listFields(final PrintStream out, final DataSchemaTable table, 
 		  final List<String> subsetcolumns ) {
     final List<DataSchemaColumn> columns = table.getColumns();
+    String concatFields = new String();
+    List<String> listofstrings = new ArrayList<String>();
+    String separator = ",\n";
     for (int i = 0; i < columns.size(); i++) {
       final DataSchemaColumn column = columns.get(i);
       String columnName = column.getName();
@@ -200,13 +204,11 @@ public class CreateHiveTableGenerator {
           if (columnName.contains(".")) {
             columnName = columnName.substring(columnName.lastIndexOf(".") + 1);
           }
-          out.print("    " + columnName + " " + column.getType().getHiveType());
-          if (i < columns.size() - 1) {
-            out.println(",");
-          } else {
-            out.println();
-          }
+          listofstrings.add("    " + columnName + " " + column.getType().getHiveType());
       }
     }
+    concatFields = StringUtils.join( listofstrings, separator );
+    out.println(concatFields);
   }
+  
 }

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
@@ -51,7 +51,7 @@ public class CreateHiveTableGenerator {
         log.info("Creating Hive " + phaseFile + " file in " + dir);
         
         generateCreateTablesFile(out, i + 1, schemaVersions.getPhase(i), schemaVersions.getPhase(i + 1),
-            "/home/hadoop/" + fileBase + ".out");
+           config.getFullTextDir() + "/" + fileBase + ".out");
       }
     }
   }

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
@@ -60,7 +60,6 @@ public class CreateHiveTableGenerator {
     out.println("sudo chown hive:hive -R /var/log/hive");
     generatePersistentTables(out, phase, input, "merged_", true, true, logFile );
     generatePersistentTables(out, phase, input, "cur_", true, false, logFile );    
-    out.println("hive -e \"");
     generateDropStatements(out, phase, "in_", tableNames, input.getSchema().getTables(), logFile );
     out.println();
     generateDropStatements(out, phase, "out_", tableNames, output.getSchema().getTables(), logFile );

--- a/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/CreateHiveTableGenerator.java
@@ -172,6 +172,9 @@ public class CreateHiveTableGenerator {
   private void listFields(final PrintStream out, final DataSchemaTable table) {
 	final List<String> keywords = Arrays.asList("timestamp", "date");
     final List<DataSchemaColumn> columns = table.getColumns();
+    String concatFields = new String();
+    List<String> listofstrings = new ArrayList<String>();
+    String separator = ",\n";
     for (int i = 0; i < columns.size(); i++) {
       final DataSchemaColumn column = columns.get(i);
       String columnName = column.getName();
@@ -179,16 +182,13 @@ public class CreateHiveTableGenerator {
         columnName = columnName.substring(columnName.lastIndexOf(".") + 1);
       }
       if (keywords.contains(columnName)) {
-          out.print("    " + "\\`" + columnName + "\\`" + " " + column.getType().getHiveType());
+    	  listofstrings.add("    " + "\\`" + columnName + "\\`" + " " + column.getType().getHiveType());
       } else {
-          out.print("    " + columnName + " " + column.getType().getHiveType());
-      }
-      if (i < columns.size() - 1) {
-        out.println(",");
-      } else {
-        out.println();
+    	  listofstrings.add("    " + columnName + " " + column.getType().getHiveType());
       }
     }
+    concatFields = StringUtils.join( listofstrings, separator );
+    out.println(concatFields);    
   }
   
   private void listFields(final PrintStream out, final DataSchemaTable table, 

--- a/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
@@ -51,7 +51,7 @@ public class FullTextCopyScriptGenerator {
   private void generateTable(final PrintStream out, final String tableName) {
     
 	if (dataIndex.isPartial(tableName)) {
-	    out.println("if ! hadoop fs -test -e " + "/current" + "; then ");	       
+	    out.println("if hadoop fs -test -e " + "/current" + "; then ");	       
     	generateMergeTable(out, tableName, "cur_");
         out.println("fi");
     	generateMergeTable(out, tableName, "in_");

--- a/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
@@ -68,7 +68,7 @@ public class FullTextCopyScriptGenerator {
   private void generatePartialTable( final PrintStream out, final String tableName, 
 		  final String outputFrom ) {
 	final FullTextTable table = textSchema.get(tableName);
-    out.println("mkdir -p " + config.getEmrLogDir() + "/full_text/" + tableName);
+    out.println("mkdir -p " + config.getFullTextDir() + "/" + tableName);
     for (final String column : table.getColumns()) {
       final String filename = config.getFullTextDir() + "/" + tableName + "/" + column;
       out.print("sudo hive -S -e \"SELECT " + table.getKey() + ", ");
@@ -82,7 +82,7 @@ public class FullTextCopyScriptGenerator {
   private void generateFullTable( final PrintStream out, final String tableName, 
 		  final String outputFrom ) {
     final FullTextTable table = textSchema.get(tableName);
-    out.println("mkdir -p " + config.getEmrLogDir() + "/full_text/" + tableName + "/fulltable");
+    out.println("mkdir -p " + config.getFullTextDir() + "/" + tableName + "/fulltable");
     final String filename = config.getFullTextDir() + "/" + tableName + "/fulltable/" + tableName;
     out.print("sudo hive -S -e \"SELECT " );
     extractFields(out, table, tableName, outputFrom, true );

--- a/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
@@ -89,6 +89,7 @@ public class FullTextCopyScriptGenerator {
   
   private void generateMergeTable( final PrintStream out, final String tableName, final String copyFrom ) {
 	final FullTextTable table = textSchema.get(tableName);
+    out.println("sudo hive -S -e \"");
 	out.println("  MERGE INTO merged_" + tableName );
 	out.println("  USING " + copyFrom + tableName + " ON merged_" + tableName
 			    + "." + table.getKey() + " = " + copyFrom + tableName + "." + table.getKey() );
@@ -100,6 +101,8 @@ public class FullTextCopyScriptGenerator {
 	insertFields(out, table, tableName, copyFrom );
 	out.println("    ); ");
 	out.println("");
+    out.println("\"");
+
   }
   
   private void setFields( final PrintStream out, final FullTextTable table, 

--- a/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
@@ -68,7 +68,7 @@ public class FullTextCopyScriptGenerator {
   private void generatePartialTable( final PrintStream out, final String tableName, 
 		  final String outputFrom ) {
 	final FullTextTable table = textSchema.get(tableName);
-    out.println("mkdir -p /home/hadoop/full_text/" + tableName);
+    out.println("mkdir -p " + config.getFullTextDir() + "/full_text/" + tableName);
     for (final String column : table.getColumns()) {
       final String filename = config.getFullTextDir() + "/" + tableName + "/" + column;
       out.print("sudo hive -S -e \"SELECT " + table.getKey() + ", ");
@@ -82,7 +82,7 @@ public class FullTextCopyScriptGenerator {
   private void generateFullTable( final PrintStream out, final String tableName, 
 		  final String outputFrom ) {
     final FullTextTable table = textSchema.get(tableName);
-    out.println("mkdir -p /home/hadoop/full_text/" + tableName + "/fulltable");
+    out.println("mkdir -p " + config.getFullTextDir() + "/full_text/" + tableName + "/fulltable");
     final String filename = config.getFullTextDir() + "/" + tableName + "/fulltable/" + tableName;
     out.print("sudo hive -S -e \"SELECT " );
     extractFields(out, table, tableName, outputFrom, true );

--- a/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
@@ -4,6 +4,10 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
 
 import edu.harvard.data.AwsUtils;
 import edu.harvard.data.DataConfig;
@@ -45,19 +49,33 @@ public class FullTextCopyScriptGenerator {
   }
 
   private void generateTable(final PrintStream out, final String tableName) {
-    final FullTextTable table = textSchema.get(tableName);
+    
+	if (dataIndex.isPartial(tableName)) {
+    	generateMergeTable(out, tableName, "cur_");
+    	generateMergeTable(out, tableName, "in_");
+    	generatePartialTable(out, tableName, "merged_");
+    	generateFullTable(out, tableName, "merged_");
+    } else {
+    	generatePartialTable( out, tableName, "in_" );
+        generateFullTable( out, tableName, "in_" );
+        out.println();
+    }
+  }
+  
+  private void generatePartialTable( final PrintStream out, final String tableName, 
+		  final String outputFrom ) {
+	final FullTextTable table = textSchema.get(tableName);
     out.println("mkdir -p /home/hadoop/full_text/" + tableName);
     for (final String column : table.getColumns()) {
       final String filename = config.getFullTextDir() + "/" + tableName + "/" + column;
-      out.println("sudo hive -S -e \"select " + table.getKey() + ", " + column + " from in_"
+      out.println("sudo hive -S -e \"select " + table.getKey() + ", " + column + " from " + outputFrom
           + tableName + ";\" > " + filename);
       out.println("gzip " + filename);
-    }
-    generateFullTable( out, tableName );
-    out.println();
+    }  
   }
 	  
-  private void generateFullTable( final PrintStream out, final String tableName) {
+  private void generateFullTable( final PrintStream out, final String tableName, 
+		  final String outputFrom ) {
     final FullTextTable table = textSchema.get(tableName);
     out.println("mkdir -p /home/hadoop/full_text/" + tableName + "/fulltable");
     final String filename = config.getFullTextDir() + "/" + tableName + "/fulltable/" + tableName;
@@ -65,7 +83,47 @@ public class FullTextCopyScriptGenerator {
     for (final String column : table.getColumns() ) {
         out.print("," + column);
     }
-    out.println(" from in_" + tableName + ";\" > " + filename);
+    out.println(" from " + outputFrom + tableName + ";\" > " + filename);
     out.println("gzip " + filename);
   }
+  
+  private void generateMergeTable( final PrintStream out, final String tableName, final String copyFrom ) {
+	final FullTextTable table = textSchema.get(tableName);
+	out.println("  MERGE INTO merged_" + tableName );
+	out.println("  USING " + copyFrom + tableName + " ON merged_" + tableName
+			    + "." + table.getKey() + " = " + copyFrom + tableName + "." + table.getKey() );
+	out.println("  WHEN MATCHED THEN UPDATE" );
+	out.print("    SET ");
+	setFields(out, table, tableName, copyFrom );
+    out.println("  WHEN NOT MATCHED THEN");
+    out.println("  INSERT VALUES (");
+	insertFields(out, table, tableName, copyFrom );
+	out.println("    ); ");
+	out.println("");
+  }
+  
+  private void setFields( final PrintStream out, final FullTextTable table, 
+		  final String tableName, final String copyFrom ) {
+  	String finalstring = new String();
+    List<String> listofstrings = new ArrayList<String>(); 
+    String separator = ",\n";
+    for (final String column : table.getColumns() ) {
+      listofstrings.add("    " + column + "=" + copyFrom + tableName + "." + column );
+    }
+    finalstring = StringUtils.join( listofstrings, separator );
+    out.println(finalstring);
+  }
+  
+  private void insertFields(final PrintStream out, final FullTextTable table,
+		  final String tableName, final String copyFrom ) {
+	String finalstring = new String();
+    List<String> listofstrings = new ArrayList<String>(); 
+    String separator = ", ";
+    for (final String column : table.getColumns() ) {
+      listofstrings.add( copyFrom + tableName + "." + column );
+    }
+    finalstring = StringUtils.join( listofstrings, separator );
+    out.println(finalstring);
+  }  
+  
 }

--- a/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
@@ -61,7 +61,7 @@ public class FullTextCopyScriptGenerator {
 	  
   private void generateFullTable( final PrintStream out, final String tableName) {
     final FullTextTable table = textSchema.get(tableName);
-    final String filename = config.getFullTextDir() + "/" + tableName + "/" + tableName;
+    final String filename = config.getFullTextDir() + "/" + tableName + "/fulltable/" + tableName;
     out.print("sudo hive -S -e \"select " + table.getKey() );
     for (final String column : table.getColumns() ) {
         out.print("," + column);

--- a/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
@@ -178,7 +178,7 @@ public class FullTextCopyScriptGenerator {
 
   private String addChecksum( final String fulltextfield ) {
 	final FormatLibrary formatLibrary = new FormatLibrary();
-	final boolean isQuotedFormat = formatLibrary.getFormat(config.getPipelineFormat())
+	final boolean isQuotedFormat = formatLibrary.getFormat(config.getFulltextFormat())
 							    .getCsvFormat()
 							    .isQuoteCharacterSet();	  
 	String checkSumString = new String();

--- a/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
@@ -53,9 +53,7 @@ public class FullTextCopyScriptGenerator {
           + tableName + ";\" > " + filename);
       out.println("gzip " + filename);
     }
-    if ( dataIndex.isPartial(tableName) ) {
-      generateFullTable( out, tableName );
-    }
+    generateFullTable( out, tableName );
     out.println();
   }
 	  

--- a/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
@@ -53,6 +53,20 @@ public class FullTextCopyScriptGenerator {
           + tableName + ";\" > " + filename);
       out.println("gzip " + filename);
     }
+    if ( dataIndex.isPartial(tableName) ) {
+      generateFullTable( out, tableName );
+    }
     out.println();
+  }
+	  
+  private void generateFullTable( final PrintStream out, final String tableName) {
+    final FullTextTable table = textSchema.get(tableName);
+    final String filename = config.getFullTextDir() + "/" + tableName + "/" + tableName;
+    out.print("sudo hive -S -e \"select " + table.getKey() );
+    for (final String column : table.getColumns() ) {
+        out.print("," + column);
+    }
+    out.println(" from in_" + tableName + ";\" > " + filename);
+    out.println("gzip " + filename);
   }
 }

--- a/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang.StringUtils;
 
 import edu.harvard.data.AwsUtils;
 import edu.harvard.data.DataConfig;
+import edu.harvard.data.FormatLibrary;
 import edu.harvard.data.pipeline.InputTableIndex;
 import edu.harvard.data.schema.fulltext.FullTextSchema;
 import edu.harvard.data.schema.fulltext.FullTextTable;
@@ -176,7 +177,21 @@ public class FullTextCopyScriptGenerator {
   }
 
   private String addChecksum( final String fulltextfield ) {
-	  return ("md5(" + fulltextfield + ")");
+	final FormatLibrary formatLibrary = new FormatLibrary();
+	final boolean isQuotedFormat = formatLibrary.getFormat(config.getPipelineFormat())
+							    .getCsvFormat()
+							    .isQuoteCharacterSet();	  
+	String checkSumString = new String();
+	
+	if (isQuotedFormat) {
+		// If quoted, then remove quotes and replace escaped double quotes with single quotes
+	    checkSumString = ("md5(substr(regexp_replace(" + fulltextfield + ", '\\" + "\"" + "\\" + "\"" + "', '" + "\\" + "\"" + "'), " +
+	    				  "2, length(regexp_replace(" + fulltextfield + ", '\\" + "\"" + "\\" + "\"" + "', '" + "\\" + "\"" +
+	    		          "')) -2) )");
+	} else {
+	    checkSumString = ("md5(" + fulltextfield + ")");
+	}
+	return checkSumString;
   }
   
   private String addTimestamp(final String fulltextfield ) {

--- a/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
@@ -58,8 +58,9 @@ public class FullTextCopyScriptGenerator {
     	generatePartialTable(out, tableName, "merged_");
     	generateFullTable(out, tableName, "merged_");
     } else {
-    	generatePartialTable( out, tableName, "in_" );
-        generateFullTable( out, tableName, "in_" );
+    	generateMergeTable(out, tableName, "in_");
+    	generatePartialTable( out, tableName, "merged_");
+    	generateFullTable(out, tableName, "merged_");
         out.println();
     }
   }

--- a/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
@@ -51,7 +51,9 @@ public class FullTextCopyScriptGenerator {
   private void generateTable(final PrintStream out, final String tableName) {
     
 	if (dataIndex.isPartial(tableName)) {
+	    out.println("if ! hadoop fs -test -e " + "/current" + "; then ");	       
     	generateMergeTable(out, tableName, "cur_");
+        out.println("fi");
     	generateMergeTable(out, tableName, "in_");
     	generatePartialTable(out, tableName, "merged_");
     	generateFullTable(out, tableName, "merged_");
@@ -152,12 +154,18 @@ public class FullTextCopyScriptGenerator {
 				    " ELSE " + "merged_" + tableName + "." + column + 
 				    " END )");
 		if (addMetadata) {
+			String timevalue = new String();
+			if (copyFrom.equals("in_")) {
+				timevalue = "current_timestamp";
+			} else {
+				timevalue = copyFrom + tableName + "." + "time_" + column;
+			}
 			listofmeta.add( "    " + "time_" + column + "=" + "( CASE " +
 					" WHEN ( " + "md5( merged_" + tableName + "." + column + " ) != md5( " + copyFrom + tableName + "." + column + " ) ) " +
-				    " THEN " + copyFrom + tableName + "." + "time_" + column + 
+				    " THEN " + timevalue + 
 				    " ELSE " + "merged_" + tableName + "." + "time_" + column + 
 				    " END )");		
-		}	
+		}
 	}
     List<String> orderList = new ArrayList<String>(listofstrings);
     if (addMetadata) orderList.addAll(listofmeta);    	

--- a/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
@@ -83,7 +83,7 @@ public class FullTextCopyScriptGenerator {
     final FullTextTable table = textSchema.get(tableName);
     out.println("mkdir -p /home/hadoop/full_text/" + tableName + "/fulltable");
     final String filename = config.getFullTextDir() + "/" + tableName + "/fulltable/" + tableName;
-    out.print("sudo hive -S -e \"SELECT " + table.getKey() );
+    out.print("sudo hive -S -e \"SELECT " );
     extractFields(out, table, tableName, outputFrom, true );
     out.println(" FROM " + outputFrom + tableName + ";\" > " + filename);
     out.println("gzip " + filename);

--- a/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
@@ -68,7 +68,7 @@ public class FullTextCopyScriptGenerator {
   private void generatePartialTable( final PrintStream out, final String tableName, 
 		  final String outputFrom ) {
 	final FullTextTable table = textSchema.get(tableName);
-    out.println("mkdir -p " + config.getFullTextDir() + "/full_text/" + tableName);
+    out.println("mkdir -p " + config.getEmrLogDir() + "/full_text/" + tableName);
     for (final String column : table.getColumns()) {
       final String filename = config.getFullTextDir() + "/" + tableName + "/" + column;
       out.print("sudo hive -S -e \"SELECT " + table.getKey() + ", ");
@@ -82,7 +82,7 @@ public class FullTextCopyScriptGenerator {
   private void generateFullTable( final PrintStream out, final String tableName, 
 		  final String outputFrom ) {
     final FullTextTable table = textSchema.get(tableName);
-    out.println("mkdir -p " + config.getFullTextDir() + "/full_text/" + tableName + "/fulltable");
+    out.println("mkdir -p " + config.getEmrLogDir() + "/full_text/" + tableName + "/fulltable");
     final String filename = config.getFullTextDir() + "/" + tableName + "/fulltable/" + tableName;
     out.print("sudo hive -S -e \"SELECT " );
     extractFields(out, table, tableName, outputFrom, true );

--- a/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
@@ -121,6 +121,7 @@ public class FullTextCopyScriptGenerator {
 		  final String tableName, final String copyFrom ) {
 	String finalstring = new String();
     List<String> listofstrings = new ArrayList<String>(); 
+    listofstrings.add(0, copyFrom + tableName + "." + table.getKey());
     String separator = ", ";
     for (final String column : table.getColumns() ) {
       listofstrings.add( copyFrom + tableName + "." + column );

--- a/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
@@ -68,8 +68,6 @@ public class FullTextCopyScriptGenerator {
     out.println("mkdir -p /home/hadoop/full_text/" + tableName);
     for (final String column : table.getColumns()) {
       final String filename = config.getFullTextDir() + "/" + tableName + "/" + column;
-      //out.println("sudo hive -S -e \"select " + table.getKey() + ", " + column + " from " + outputFrom
-      //    + tableName + ";\" > " + filename);
       out.print("sudo hive -S -e \"SELECT " + table.getKey() + ", ");
       extractField( out, column, true );
       out.print(" FROM " + outputFrom + tableName + ";\" > " + filename);
@@ -84,9 +82,7 @@ public class FullTextCopyScriptGenerator {
     out.println("mkdir -p /home/hadoop/full_text/" + tableName + "/fulltable");
     final String filename = config.getFullTextDir() + "/" + tableName + "/fulltable/" + tableName;
     out.print("sudo hive -S -e \"SELECT " + table.getKey() );
-    for (final String column : table.getColumns() ) {
-        out.print("," + column);
-    }
+    extractFields(out, table, tableName, outputFrom, true );
     out.println(" FROM " + outputFrom + tableName + ";\" > " + filename);
     out.println("gzip " + filename);
   }
@@ -99,59 +95,98 @@ public class FullTextCopyScriptGenerator {
 			    + "." + table.getKey() + " = " + copyFrom + tableName + "." + table.getKey() );
 	out.println("  WHEN MATCHED THEN UPDATE" );
 	out.print("    SET ");
-	setFields(out, table, tableName, copyFrom );
+	setFields(out, table, tableName, copyFrom, true );
     out.println("  WHEN NOT MATCHED THEN");
     out.println("  INSERT VALUES (");
-	insertFields(out, table, tableName, copyFrom );
+	insertFields(out, table, tableName, copyFrom, true );
 	out.println("    ); ");
 	out.println("");
     out.println("\"");
+  }
+  
+  private void extractFields( final PrintStream out, final FullTextTable table,
+		  final String tableName, final String extractFrom, final boolean addMetadata ) {
+	String finalstring = new String();
+	List<String> listofstrings = new ArrayList<String>();
+	List<String> listofmeta = new ArrayList<String>();
+	String separator = ",\n";
+    listofstrings.add(0, table.getKey());
+	for (final String column : table.getColumns() ) {
+	  listofstrings.add( column );
+	  if ( addMetadata && !column.equals( table.getKey()) ) {
+		  listofmeta.add( addTimestamp( column));
+	  }
+	}
+	List<String> orderList = new ArrayList<String>(listofstrings);
+	if (addMetadata) orderList.addAll(listofmeta);    
+	finalstring = StringUtils.join( orderList, separator );
+	out.println(finalstring);  
   }
   
   private void extractField( final PrintStream out, final String textcolumn, 
 		  final boolean addMetadata ) {
 	String finalstring = new String();
 	List<String> listofstrings = new ArrayList<String>();
+    List<String> listofmeta = new ArrayList<String>();
 	String separator = ", ";
 	listofstrings.add(textcolumn);
 	if (addMetadata) {
 	    listofstrings.add( addChecksum(textcolumn));
-	    listofstrings.add( addTimestamp());
+		listofmeta.add( addTimestamp(textcolumn));
 	}
-	finalstring = StringUtils.join( listofstrings, separator );
+    List<String> orderList = new ArrayList<String>(listofstrings);
+    if (addMetadata) orderList.addAll(listofmeta);    	
+	finalstring = StringUtils.join( orderList, separator );
 	out.println(finalstring);
   }
   
   private String addChecksum( final String fulltextfield ) {
-	  return "md5(" + fulltextfield + ")";
+	  return ("md5(" + fulltextfield + ")");
   }
   
-  private String addTimestamp() {
-	  return "current_timestamp";
+  private String addTimestamp(final String fulltextfield ) {
+	  return ("time_" + fulltextfield );
   }
     
   private void setFields( final PrintStream out, final FullTextTable table, 
-		  final String tableName, final String copyFrom ) {
+		  final String tableName, final String copyFrom, final boolean addMetadata ) {
   	String finalstring = new String();
-    List<String> listofstrings = new ArrayList<String>(); 
+    List<String> listofstrings = new ArrayList<String>();
+    List<String> listofmeta = new ArrayList<String>();
     String separator = ",\n";
     for (final String column : table.getColumns() ) {
       listofstrings.add("    " + column + "=" + copyFrom + tableName + "." + column );
+      
+      if ( addMetadata && !column.equals( table.getKey()) ) {
+    	  listofmeta.add("    " + "time_" + column + "=" + "current_timestamp" );
+      }
     }
-    finalstring = StringUtils.join( listofstrings, separator );
+    List<String> orderList = new ArrayList<String>(listofstrings);
+    if (addMetadata) orderList.addAll(listofmeta);    
+    finalstring = StringUtils.join( orderList, separator );
     out.println(finalstring);
   }
   
   private void insertFields(final PrintStream out, final FullTextTable table,
-		  final String tableName, final String copyFrom ) {
+		  final String tableName, final String copyFrom, final boolean addMetadata ) {
 	String finalstring = new String();
-    List<String> listofstrings = new ArrayList<String>(); 
+    List<String> listofstrings = new ArrayList<String>();
+    List<String> listofmeta = new ArrayList<String>();
     listofstrings.add(0, copyFrom + tableName + "." + table.getKey());
     String separator = ", ";
     for (final String column : table.getColumns() ) {
       listofstrings.add( copyFrom + tableName + "." + column );
+      
+	  if ( addMetadata && !column.equals( table.getKey()) ) {
+		  //String timestampField = addTimestamp( columnName );
+		  //listofmeta.add( addCheckedField(timestampField, timestamptype.getHiveType(), true ));
+		  listofmeta.add( "current_timestamp" );
+	  }
+      
     }
-    finalstring = StringUtils.join( listofstrings, separator );
+    List<String> orderList = new ArrayList<String>(listofstrings);
+    if (addMetadata) orderList.addAll(listofmeta);
+    finalstring = StringUtils.join( orderList, separator );
     out.println(finalstring);
   }  
   

--- a/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
@@ -61,6 +61,7 @@ public class FullTextCopyScriptGenerator {
 	  
   private void generateFullTable( final PrintStream out, final String tableName) {
     final FullTextTable table = textSchema.get(tableName);
+    out.println("mkdir -p /home/hadoop/full_text/" + tableName + "/fulltable");
     final String filename = config.getFullTextDir() + "/" + tableName + "/fulltable/" + tableName;
     out.print("sudo hive -S -e \"select " + table.getKey() );
     for (final String column : table.getColumns() ) {

--- a/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/FullTextCopyScriptGenerator.java
@@ -212,9 +212,9 @@ public class FullTextCopyScriptGenerator {
       listofstrings.add( copyFrom + tableName + "." + column );
       
 	  if ( addMetadata && !column.equals( table.getKey()) ) {
-		  //String timestampField = addTimestamp( columnName );
-		  //listofmeta.add( addCheckedField(timestampField, timestamptype.getHiveType(), true ));
-		  listofmeta.add( "current_timestamp" );
+		  if (copyFrom.equals("cur_") ) {
+			  listofmeta.add( copyFrom + tableName + "." + addTimestamp( column) );
+		  } else listofmeta.add( "current_timestamp" );
 	  }
       
     }

--- a/java/data_client/src/main/java/edu/harvard/data/generator/S3ToRedshiftLoaderGenerator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/generator/S3ToRedshiftLoaderGenerator.java
@@ -130,7 +130,7 @@ public class S3ToRedshiftLoaderGenerator {
 
     // Copy the final incoming data into final the stage table
     out.println("COPY " + stageTableName + " " + columnList + " FROM " + s3Location
-        + " CREDENTIALS " + getCredentials() + " DELIMITER '\\t' TRUNCATECOLUMNS GZIP;");
+        + " CREDENTIALS " + getCredentials() + " DELIMITER '\\t' TRUNCATECOLUMNS GZIP NULL AS '\\0';");
 
     // Use an inner join with the staging table to delete the rows from the
     // target table that are being updated.
@@ -172,7 +172,7 @@ public class S3ToRedshiftLoaderGenerator {
     out.println("ANALYZE " + tableName + ";");
     out.println(
         "COPY " + tableName + " " + columnList + " FROM " + getLocation(table.getTableName())
-        + " CREDENTIALS " + getCredentials() + " DELIMITER '\\t' TRUNCATECOLUMNS GZIP;");
+        + " CREDENTIALS " + getCredentials() + " DELIMITER '\\t' TRUNCATECOLUMNS GZIP NULL AS '\\0';");
     out.println("VACUUM " + tableName + ";");
     out.println("ANALYZE " + tableName + ";");
     out.println();

--- a/java/data_client/src/main/java/edu/harvard/data/io/DelimitedFileIterator.java
+++ b/java/data_client/src/main/java/edu/harvard/data/io/DelimitedFileIterator.java
@@ -10,6 +10,8 @@ import java.util.Iterator;
 
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import edu.harvard.data.DataTable;
 import edu.harvard.data.TableFormat;
@@ -52,6 +54,8 @@ public class DelimitedFileIterator<T extends DataTable> implements Iterator<T>, 
   private final File file;
   protected InputStream inStream;
   private int line;
+
+  private static final Logger log = LogManager.getLogger();
 
   /**
    * Create a new iterator.
@@ -144,6 +148,7 @@ public class DelimitedFileIterator<T extends DataTable> implements Iterator<T>, 
       while (cause instanceof InvocationTargetException) {
         cause = cause.getCause();
       }
+      log.info("IterationException on line: " + line );
       throw new IterationException(cause);
     }
   }

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/Pipeline.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/Pipeline.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.amazonaws.services.datapipeline.model.PutPipelineDefinitionRequest;
 import com.amazonaws.services.s3.model.S3ObjectId;
@@ -24,6 +26,9 @@ public class Pipeline {
   private final PipelineObjectBase schedule;
   private final String schemaVersion;
   private final String runId;
+  
+  private static final Logger log = LogManager.getLogger();
+
 
   public Pipeline(final String name, final DataConfig config, final String pipelineId,
       final PipelineFactory factory, final String schemaVersion, final String runId)
@@ -55,6 +60,7 @@ public class Pipeline {
 
   private PipelineObjectBase createEmr() {
     final PipelineObjectBase emr = factory.getEmr(name + "_Emr_Cluster");
+    log.info("Pipelineobject: " + emr.getPipelineObject());
     emr.set("bootstrapAction", emrBootstrapAction());
     return emr;
   }

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/Pipeline.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/Pipeline.java
@@ -24,6 +24,7 @@ public class Pipeline {
   private final PipelineObjectBase redshift;
   private final PipelineObjectBase emr;
   private final PipelineObjectBase schedule;
+  private final PipelineObjectBase configuration;
   private final String schemaVersion;
   private final String runId;
   
@@ -41,6 +42,7 @@ public class Pipeline {
     this.runId = runId;
     this.schedule = factory.getSchedule();
     this.redshift = factory.getRedshift();
+    this.configuration = factory.testEmrHiveConfiguration();
     this.emr = createEmr();
     createDefaultObject();
   }
@@ -58,8 +60,9 @@ public class Pipeline {
     return defaultObj;
   }
 
-  private PipelineObjectBase createEmr() {
+  private PipelineObjectBase createEmr() {	 
     final PipelineObjectBase emr = factory.getEmr(name + "_Emr_Cluster");
+    log.info("EmrConfig: " + this.configuration.getPipelineObject());
     log.info("Pipelineobject: " + emr.getPipelineObject());
     emr.set("bootstrapAction", emrBootstrapAction());
     return emr;

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/Pipeline.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/Pipeline.java
@@ -24,7 +24,6 @@ public class Pipeline {
   private final PipelineObjectBase redshift;
   private final PipelineObjectBase emr;
   private final PipelineObjectBase schedule;
-  private final PipelineObjectBase configuration;
   private final String schemaVersion;
   private final String runId;
   
@@ -42,7 +41,6 @@ public class Pipeline {
     this.runId = runId;
     this.schedule = factory.getSchedule();
     this.redshift = factory.getRedshift();
-    this.configuration = factory.testEmrHiveConfiguration();
     this.emr = createEmr();
     createDefaultObject();
   }
@@ -62,7 +60,6 @@ public class Pipeline {
 
   private PipelineObjectBase createEmr() {	 
     final PipelineObjectBase emr = factory.getEmr(name + "_Emr_Cluster");
-    log.info("EmrConfig: " + this.configuration.getPipelineObject());
     log.info("Pipelineobject: " + emr.getPipelineObject());
     emr.set("bootstrapAction", emrBootstrapAction());
     return emr;

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -316,6 +316,7 @@ public class PipelineFactory {
   public PipelineObjectBase testEmrConfiguration() {
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "TestEmrConfiguration", "EmrConfiguration");
 	  obj.set("ref", testEmrHiveConfiguration() );
+	  allObjects.add(obj);
 	  return obj;
   }
   

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -103,7 +103,7 @@ public class PipelineFactory {
     }
     if (config.getEmrConfiguration() != null ) {
       obj.set("configuration", testEmrHiveConfiguration() );
-      obj.set("ebsRootVolumeSize", "500" );
+      //obj.set("ebsRootVolumeSize", "500" );
       //obj.set("masterEbsConfiguration", testMasterEbsConfig() );
       //obj.set("coreEbsConfiguration", testMasterEbsConfig() );
     }

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -104,7 +104,7 @@ public class PipelineFactory {
     if (config.getEmrConfiguration() != null ) {
       obj.set("configuration", testEmrHiveConfiguration() );
       obj.set("masterEbsConfiguration", testMasterEbsConfig() );
-      obj.set("coreEbsConfiguration", testMasterEbsConfig() );
+      //obj.set("coreEbsConfiguration", testMasterEbsConfig() );
     }
     allObjects.add(obj);
     return obj;
@@ -337,7 +337,6 @@ public class PipelineFactory {
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EBSConfiguration", "EbsConfiguration"); 
 	  obj.set("ebsOptimized", "true");
 	  obj.set("ebsBlockDeviceConfig", testEbsBlockDeviceConfig());
-	  allObjects.add(obj);
 	  return obj;
   }
   

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -98,6 +98,9 @@ public class PipelineFactory {
         obj.set("taskInstanceBidPrice", config.getEmrTaskBidPrice());
       }
     }
+    if (config.getEmrConfiguration() != null ) {
+    	obj.set("configuration", config.getEmrConfiguration());
+    }
     allObjects.add(obj);
     return obj;
   }

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -314,7 +314,7 @@ public class PipelineFactory {
   
   //testing
   public PipelineObjectBase testEmrConfiguration() {
-	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EmrConfiguration", "EmrConfiguration");
+	  final PipelineObjectBase obj = new PipelineObjectBase(config, "TestEmrConfiguration", "EmrConfiguration");
 	  obj.set("ref", testEmrHiveConfiguration() );
 	  return obj;
   }

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -102,7 +102,7 @@ public class PipelineFactory {
       }
     }
     if (config.getEmrConfiguration() != null ) {
-    	obj.set("configuration", testEmrConfiguration() );
+    	obj.set("configuration", testEmrHiveConfiguration() );
     }
     allObjects.add(obj);
     return obj;

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -314,14 +314,14 @@ public class PipelineFactory {
   
   //testing
   public PipelineObjectBase testEmrConfiguration() {
-	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EMR Configuration", "EmrConfiguration");
+	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EMRConfiguration", "EmrConfiguration");
 	  obj.set("ref", testEmrHiveConfiguration() );
 	  return obj;
   }
   
   public PipelineObjectBase testEmrHiveConfiguration() {
 	  
-	  final PipelineObjectBase obj = new PipelineObjectBase(config, "configureEmrHiveSite", "HiveSiteConfiguration"); 
+	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EMRConfiguration", "EMRConfiguration"); 
 	  Map<String,String> hiveProperties = new HashMap<String,String>();
 		hiveProperties.put("hive.support.concurrency","true");
 		hiveProperties.put("hive.enforce.bucketing","true");
@@ -340,7 +340,7 @@ public class PipelineFactory {
 		
   public PipelineObjectBase testEmrFsConfiguration() {
 	  
-	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EMR Configuration", "EmrConfiguration");
+	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EMRConfiguration", "EmrConfiguration");
 
       Map<String,String> emrfsProperties = new HashMap<String,String>();
         emrfsProperties.put("fs.s3.enableServerSideEncryption","true");

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -1,12 +1,15 @@
 package edu.harvard.data.pipeline;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 
 import com.amazonaws.services.datapipeline.model.PipelineObject;
 import com.amazonaws.services.s3.model.S3ObjectId;
+import com.amazonaws.services.elasticmapreduce.model.Configuration;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -99,7 +102,7 @@ public class PipelineFactory {
       }
     }
     if (config.getEmrConfiguration() != null ) {
-    	obj.set("configuration", config.getEmrConfiguration());
+    	obj.set("configuration", testEmrConfiguration() );
     }
     allObjects.add(obj);
     return obj;
@@ -307,6 +310,47 @@ public class PipelineFactory {
       objects.add(obj.getPipelineObject());
     }
     return objects;
+  }
+  
+  //testing
+  public PipelineObjectBase testEmrConfiguration() {
+	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EMR Configuration", "EmrConfiguration");
+	  obj.set("ref", testEmrHiveConfiguration() );
+	  return obj;
+  }
+  
+  public PipelineObjectBase testEmrHiveConfiguration() {
+	  
+	  final PipelineObjectBase obj = new PipelineObjectBase(config, "configureEmrHiveSite", "HiveSiteConfiguration"); 
+	  Map<String,String> hiveProperties = new HashMap<String,String>();
+		hiveProperties.put("hive.support.concurrency","true");
+		hiveProperties.put("hive.enforce.bucketing","true");
+		hiveProperties.put("hive.exec.dynamic.partition.mode","nonstrict");
+		hiveProperties.put("hive.txn.manager","org.apache.hadoop.hive.ql.lockmgr.DbTxnManager");
+		hiveProperties.put("hive.compactor.initiator.on","true");
+		hiveProperties.put("hive.compactor.worker.threads","2");	
+		
+	  Configuration customEmrHiveConfig = new Configuration()
+			  .withClassification("hive-site")
+			  .withProperties(hiveProperties);
+	  obj.set("classification", customEmrHiveConfig.getClassification());
+	  obj.set("properties", customEmrHiveConfig.getProperties());
+	  return obj;
+  }
+		
+  public PipelineObjectBase testEmrFsConfiguration() {
+	  
+	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EMR Configuration", "EmrConfiguration");
+
+      Map<String,String> emrfsProperties = new HashMap<String,String>();
+        emrfsProperties.put("fs.s3.enableServerSideEncryption","true");
+
+	  Configuration customEmrConfig = new Configuration()
+				.withClassification("emrfs-site")
+				.withProperties(emrfsProperties);
+	  obj.set("classification", customEmrConfig.getClassification());
+	  obj.set("properties", customEmrConfig.getProperties());
+	  return obj;
   }
 
 }

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -337,6 +337,7 @@ public class PipelineFactory {
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EBSConfiguration", "EbsConfiguration"); 
 	  obj.set("ebsOptimized", "true");
 	  obj.set("ebsBlockDeviceConfig", testEbsBlockDeviceConfig());
+	  allObjects.add(obj);	  
 	  return obj;
   }
   

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -341,7 +341,7 @@ public class PipelineFactory {
 		
   public PipelineObjectBase testEmrFsConfiguration() {
 	  
-	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EmrConfiguration", "EmrConfiguration");
+	  final PipelineObjectBase obj = new PipelineObjectBase(config, "TestEmrFsConfiguration", "EmrConfiguration");
 
       Map<String,String> emrfsProperties = new HashMap<String,String>();
         emrfsProperties.put("fs.s3.enableServerSideEncryption","true");

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -103,7 +103,7 @@ public class PipelineFactory {
     }
     if (config.getEmrConfiguration() != null ) {
       obj.set("configuration", testEmrHiveConfiguration() );
-      obj.set("EbsRootVolumeSize", "500" );
+      obj.set("ebsRootVolumeSize", "500" );
       //obj.set("masterEbsConfiguration", testMasterEbsConfig() );
       //obj.set("coreEbsConfiguration", testMasterEbsConfig() );
     }

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -337,7 +337,7 @@ public class PipelineFactory {
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EBSConfiguration", "EbsConfiguration"); 
 	  obj.set("ebsOptimized", "true");
 	  obj.set("ebsBlockDeviceConfig", testEbsBlockDeviceConfig());
-
+	  allObjects.add(obj);
 	  return obj;
   }
   
@@ -345,6 +345,7 @@ public class PipelineFactory {
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EbsBlockDeviceConfig", "EbsBlockDeviceConfig");
 	  obj.set("volumesPerInstance", "1");
 	  obj.set("volumeSpecification", testVolumeSpecConfig() );
+	  allObjects.add(obj);
 	  return obj;
   }
   
@@ -352,7 +353,8 @@ public class PipelineFactory {
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "VolumeSpecification", "VolumeSpecification");
       obj.set("sizeInGB", "500");
       obj.set("volumeType", "standard");
-	  return obj;
+	  allObjects.add(obj);
+      return obj;
   }
   
   public ArrayList<PipelineObjectBase> testCreateEmrConfigObjects() {

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -342,7 +342,7 @@ public class PipelineFactory {
   }
   
   public PipelineObjectBase testEbsBlockDeviceConfig() {
-	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EbsBlockDeviceConfig", "EbsBlockDeviceConfig");
+	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EbsBlkDeviceConfig", "EbsBlockDeviceConfig");
 	  obj.set("volumesPerInstance", "1");
 	  obj.set("volumeSpecification", testVolumeSpecConfig() );
 	  allObjects.add(obj);
@@ -350,7 +350,7 @@ public class PipelineFactory {
   }
   
   public PipelineObjectBase testVolumeSpecConfig() {
-	  final PipelineObjectBase obj = new PipelineObjectBase(config, "VolumeSpecification", "VolumeSpecification");
+	  final PipelineObjectBase obj = new PipelineObjectBase(config, "VolSpecification", "VolumeSpecification");
       obj.set("sizeInGB", "500");
       obj.set("volumeType", "standard");
 	  allObjects.add(obj);

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -103,8 +103,9 @@ public class PipelineFactory {
     }
     if (config.getEmrConfiguration() != null ) {
       obj.set("configuration", testEmrHiveConfiguration() );
-      obj.set("masterEbsConfiguration", testMasterEbsConfig() );
-      obj.set("coreEbsConfiguration", testMasterEbsConfig() );
+      obj.set("EbsRootVolumeSize", "500" );
+      //obj.set("masterEbsConfiguration", testMasterEbsConfig() );
+      //obj.set("coreEbsConfiguration", testMasterEbsConfig() );
     }
     allObjects.add(obj);
     return obj;

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -335,7 +335,6 @@ public class PipelineFactory {
   
   public PipelineObjectBase testMasterEbsConfig() {
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EBSConfiguration", "EbsConfiguration"); 
-	  obj.set("ebsOptimized", "true");
 	  obj.set("ebsBlockDeviceConfig", testEbsBlockDeviceConfig());
 	  allObjects.add(obj);	  
 	  return obj;

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -337,6 +337,7 @@ public class PipelineFactory {
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EBSConfiguration", "EbsConfiguration"); 
 	  obj.set("ebsOptimized", "true");
 	  obj.set("ebsBlockDeviceConfig", testEbsBlockDeviceConfig());
+	  allObjects.add(obj);
 	  return obj;
   }
   

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -337,7 +337,6 @@ public class PipelineFactory {
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EBSConfiguration", "EbsConfiguration"); 
 	  obj.set("ebsOptimized", "true");
 	  obj.set("ebsBlockDeviceConfig", testEbsBlockDeviceConfig());
-	  allObjects.add(obj);
 	  return obj;
   }
   
@@ -345,7 +344,6 @@ public class PipelineFactory {
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EbsBlkDeviceConfig", "EbsBlockDeviceConfig");
 	  obj.set("volumesPerInstance", "1");
 	  obj.set("volumeSpecification", testVolumeSpecConfig() );
-	  allObjects.add(obj);
 	  return obj;
   }
   
@@ -353,7 +351,6 @@ public class PipelineFactory {
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "VolSpecification", "VolumeSpecification");
       obj.set("sizeInGB", "500");
       obj.set("volumeType", "standard");
-	  allObjects.add(obj);
       return obj;
   }
   

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -324,6 +324,7 @@ public class PipelineFactory {
 	  
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "hivesite", "EmrConfiguration"); 
 
+	  obj.set("classification", "hive-site" );
 	  obj.set("property", testCreateEmrConfigObjects() );
 	  
 	  allObjects.add(obj);

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -345,6 +345,7 @@ public class PipelineFactory {
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EbsBlkDeviceConfig", "EbsBlockDeviceConfig");
 	  obj.set("volumesPerInstance", "1");
 	  obj.set("volumeSpecification", testVolumeSpecConfig() );
+	  allObjects.add(obj);
 	  return obj;
   }
   
@@ -352,6 +353,7 @@ public class PipelineFactory {
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "VolSpecification", "VolumeSpecification");
       obj.set("sizeInGB", "500");
       obj.set("volumeType", "standard");
+	  allObjects.add(obj);
       return obj;
   }
   

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -104,7 +104,7 @@ public class PipelineFactory {
     if (config.getEmrConfiguration() != null ) {
       obj.set("configuration", testEmrHiveConfiguration() );
       obj.set("masterEbsConfiguration", testMasterEbsConfig() );
-      //obj.set("coreEbsConfiguration", testMasterEbsConfig() );
+      obj.set("coreEbsConfiguration", testMasterEbsConfig() );
     }
     allObjects.add(obj);
     return obj;
@@ -336,7 +336,7 @@ public class PipelineFactory {
   public PipelineObjectBase testMasterEbsConfig() {
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EBSConfiguration", "EbsConfiguration"); 
 	  obj.set("ebsBlockDeviceConfig", testEbsBlockDeviceConfig());
-	  allObjects.add(obj);	  
+	  if (!allObjects.contains(obj)) allObjects.add(obj);	  
 	  return obj;
   }
   
@@ -344,7 +344,7 @@ public class PipelineFactory {
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EbsBlkDeviceConfig", "EbsBlockDeviceConfig");
 	  obj.set("volumesPerInstance", "1");
 	  obj.set("volumeSpecification", testVolumeSpecConfig() );
-	  allObjects.add(obj);
+	  if (!allObjects.contains(obj)) allObjects.add(obj);	  
 	  return obj;
   }
   
@@ -352,7 +352,7 @@ public class PipelineFactory {
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "VolSpecification", "VolumeSpecification");
       obj.set("sizeInGB", "500");
       obj.set("volumeType", "standard");
-	  allObjects.add(obj);
+	  if (!allObjects.contains(obj)) allObjects.add(obj);	  
       return obj;
   }
   

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -103,6 +103,8 @@ public class PipelineFactory {
     }
     if (config.getEmrConfiguration() != null ) {
       obj.set("configuration", testEmrHiveConfiguration() );
+      obj.set("masterEbsConfiguration", testMasterEbsConfig() );
+      obj.set("coreEbsConfiguration", testMasterEbsConfig() );
     }
     allObjects.add(obj);
     return obj;
@@ -328,6 +330,28 @@ public class PipelineFactory {
 	  obj.set("property", testCreateEmrConfigObjects() );
 	  
 	  allObjects.add(obj);
+	  return obj;
+  }
+  
+  public PipelineObjectBase testMasterEbsConfig() {
+	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EBSConfiguration", "EbsConfiguration"); 
+	  obj.set("ebsOptimized", "true");
+	  obj.set("ebsBlockDeviceConfig", testEbsBlockDeviceConfig());
+
+	  return obj;
+  }
+  
+  public PipelineObjectBase testEbsBlockDeviceConfig() {
+	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EbsBlockDeviceConfig", "EbsBlockDeviceConfig");
+	  obj.set("volumesPerInstance", "1");
+	  obj.set("volumeSpecification", testVolumeSpecConfig() );
+	  return obj;
+  }
+  
+  public PipelineObjectBase testVolumeSpecConfig() {
+	  final PipelineObjectBase obj = new PipelineObjectBase(config, "VolumeSpecification", "VolumeSpecification");
+      obj.set("sizeInGB", "500");
+      obj.set("volumeType", "standard");
 	  return obj;
   }
   

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -314,14 +314,14 @@ public class PipelineFactory {
   
   //testing
   public PipelineObjectBase testEmrConfiguration() {
-	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EMRConfiguration", "EmrConfiguration");
+	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EmrConfiguration", "EmrConfiguration");
 	  obj.set("ref", testEmrHiveConfiguration() );
 	  return obj;
   }
   
   public PipelineObjectBase testEmrHiveConfiguration() {
 	  
-	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EMRConfiguration", "EMRConfiguration"); 
+	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EmrConfiguration", "EmrConfiguration"); 
 	  Map<String,String> hiveProperties = new HashMap<String,String>();
 		hiveProperties.put("hive.support.concurrency","true");
 		hiveProperties.put("hive.enforce.bucketing","true");
@@ -335,12 +335,13 @@ public class PipelineFactory {
 			  .withProperties(hiveProperties);
 	  obj.set("classification", customEmrHiveConfig.getClassification());
 	  obj.set("properties", customEmrHiveConfig.getProperties());
+	  allObjects.add(obj);
 	  return obj;
   }
 		
   public PipelineObjectBase testEmrFsConfiguration() {
 	  
-	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EMRConfiguration", "EmrConfiguration");
+	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EmrConfiguration", "EmrConfiguration");
 
       Map<String,String> emrfsProperties = new HashMap<String,String>();
         emrfsProperties.put("fs.s3.enableServerSideEncryption","true");

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -324,7 +324,7 @@ public class PipelineFactory {
 	  
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "hivesite", "EmrConfiguration"); 
 
-	  obj.set("Property", testCreateEmrConfigObjects() );
+	  obj.set("property", testCreateEmrConfigObjects() );
 	  
 	  allObjects.add(obj);
 	  return obj;

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -352,7 +352,7 @@ public class PipelineFactory {
   public PipelineObjectBase testCreateEmrConfigObject(final String key, final String value ) {
 
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, key, "Property"); 
-	  obj.set("key", key);
+  	  obj.set("key", key.replace("-", ".") );
 	  obj.set("value", value);
 	  allObjects.add(obj);
 	  return obj;

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -102,7 +102,10 @@ public class PipelineFactory {
       }
     }
     if (config.getEmrConfiguration() != null ) {
-    	obj.set("configuration", testEmrHiveConfiguration() );
+	  Map<String,String> hivesite = new HashMap<String,String>();
+	  hivesite.put("ref","hivesite");
+      obj.set("configuration", hivesite );
+      testEmrHiveConfiguration();
     }
     allObjects.add(obj);
     return obj;
@@ -322,20 +325,38 @@ public class PipelineFactory {
   
   public PipelineObjectBase testEmrHiveConfiguration() {
 	  
-	  final PipelineObjectBase obj = new PipelineObjectBase(config, "EmrConfiguration", "EmrConfiguration"); 
-	  Map<String,String> hiveProperties = new HashMap<String,String>();
-		hiveProperties.put("hive.support.concurrency","true");
-		hiveProperties.put("hive.enforce.bucketing","true");
-		hiveProperties.put("hive.exec.dynamic.partition.mode","nonstrict");
-		hiveProperties.put("hive.txn.manager","org.apache.hadoop.hive.ql.lockmgr.DbTxnManager");
-		hiveProperties.put("hive.compactor.initiator.on","true");
-		hiveProperties.put("hive.compactor.worker.threads","2");	
-		
-	  Configuration customEmrHiveConfig = new Configuration()
-			  .withClassification("hive-site")
-			  .withProperties(hiveProperties);
-	  obj.set("classification", customEmrHiveConfig.getClassification());
-	  obj.set("properties", hiveProperties );
+	  final PipelineObjectBase obj = new PipelineObjectBase(config, "hivesite", "EmrConfiguration"); 
+
+	  // Create Property
+	  List<Map<String, String>> propertylist = new ArrayList<Map<String, String>>();
+	  Map<String, String> hProperties = new HashMap<String,String>();
+	  hProperties.put("hive-support-concurrency", "true");
+	  hProperties.put("hive-enforce-bucketing", "true");
+	  hProperties.put("hive-exec-dynamic-partition-mode", "nonstrict");
+	  hProperties.put("hive-txn-manager", "org.apache.hadoop.hive.ql.lockmgr.DbTxnManager");
+	  hProperties.put("hive-compactor-initiator-on", "true");
+	  hProperties.put("hive-compactor-worker-threads", "2");
+	  for( final String hProperty: hProperties.keySet() ) {
+	  	Map<String, String> mMap = new HashMap<String, String>();
+	  	mMap.put( "ref", hProperty );
+	  	propertylist.add( mMap );
+	  }
+	  obj.set("property", propertylist );
+	  
+	  // Create Data Pipeline Objects for each property
+	  for( final String hProperty: hProperties.keySet() ) {
+		  testCreateEmrConfigObjects( hProperty, hProperties.get(hProperty));
+	  }
+	  
+	  allObjects.add(obj);
+	  return obj;
+  }
+  
+  public PipelineObjectBase testCreateEmrConfigObjects(final String key, final String value ) {
+
+	  final PipelineObjectBase obj = new PipelineObjectBase(config, key, "Property"); 
+	  obj.set("key", key);
+	  obj.set("value", value);
 	  allObjects.add(obj);
 	  return obj;
   }

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -102,10 +102,7 @@ public class PipelineFactory {
       }
     }
     if (config.getEmrConfiguration() != null ) {
-	  Map<String,String> hivesite = new HashMap<String,String>();
-	  hivesite.put("ref","hivesite");
-      obj.set("configuration", hivesite );
-      testEmrHiveConfiguration();
+      obj.set("configuration", testEmrHiveConfiguration() );
     }
     allObjects.add(obj);
     return obj;
@@ -327,8 +324,17 @@ public class PipelineFactory {
 	  
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "hivesite", "EmrConfiguration"); 
 
-	  // Create Property
-	  List<Map<String, String>> propertylist = new ArrayList<Map<String, String>>();
+	  obj.set("Property", testCreateEmrConfigObjects() );
+	  
+	  allObjects.add(obj);
+	  return obj;
+  }
+  
+  public ArrayList<PipelineObjectBase> testCreateEmrConfigObjects() {
+
+	  ArrayList<PipelineObjectBase> listconfigobjects = new ArrayList<PipelineObjectBase>();
+	  
+	  // Create Properties
 	  Map<String, String> hProperties = new HashMap<String,String>();
 	  hProperties.put("hive-support-concurrency", "true");
 	  hProperties.put("hive-enforce-bucketing", "true");
@@ -337,22 +343,12 @@ public class PipelineFactory {
 	  hProperties.put("hive-compactor-initiator-on", "true");
 	  hProperties.put("hive-compactor-worker-threads", "2");
 	  for( final String hProperty: hProperties.keySet() ) {
-	  	Map<String, String> mMap = new HashMap<String, String>();
-	  	mMap.put( "ref", hProperty );
-	  	propertylist.add( mMap );
-	  }
-	  obj.set("property", propertylist );
-	  
-	  // Create Data Pipeline Objects for each property
-	  for( final String hProperty: hProperties.keySet() ) {
-		  testCreateEmrConfigObjects( hProperty, hProperties.get(hProperty));
-	  }
-	  
-	  allObjects.add(obj);
-	  return obj;
+	  	listconfigobjects.add( testCreateEmrConfigObject(hProperty, hProperties.get( hProperty)));
+	  }	 
+	  return listconfigobjects;
   }
-  
-  public PipelineObjectBase testCreateEmrConfigObjects(final String key, final String value ) {
+
+  public PipelineObjectBase testCreateEmrConfigObject(final String key, final String value ) {
 
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, key, "Property"); 
 	  obj.set("key", key);
@@ -360,7 +356,7 @@ public class PipelineFactory {
 	  allObjects.add(obj);
 	  return obj;
   }
-		
+  
   public PipelineObjectBase testEmrFsConfiguration() {
 	  
 	  final PipelineObjectBase obj = new PipelineObjectBase(config, "TestEmrFsConfiguration", "EmrConfiguration");

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineFactory.java
@@ -334,7 +334,7 @@ public class PipelineFactory {
 			  .withClassification("hive-site")
 			  .withProperties(hiveProperties);
 	  obj.set("classification", customEmrHiveConfig.getClassification());
-	  obj.set("properties", customEmrHiveConfig.getProperties());
+	  obj.set("properties", hiveProperties );
 	  allObjects.add(obj);
 	  return obj;
   }

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineObjectBase.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineObjectBase.java
@@ -39,9 +39,12 @@ public class PipelineObjectBase {
   }
 
   protected void set(final String key, final Map<String, String> ref) {
+	final List<Field> subfields;
+	subfields = new ArrayList<Field>();
 	for (final String item : ref.keySet()) {
-	    fields.add(new Field().withKey(item).withStringValue( ref.get(item)));
+	    subfields.add(new Field().withKey(item).withStringValue( ref.get(item)));
 	}
+	fields.add(new Field().withKey(key).withStringValue(subfields.toString()));
   }  
   
   public void setSuccess(final PipelineObjectBase success) {

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineObjectBase.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineObjectBase.java
@@ -6,7 +6,6 @@ import java.util.Map;
 
 import com.amazonaws.services.datapipeline.model.Field;
 import com.amazonaws.services.datapipeline.model.PipelineObject;
-import com.amazonaws.services.elasticmapreduce.model.Configuration;
 
 
 import edu.harvard.data.DataConfig;
@@ -38,6 +37,15 @@ public class PipelineObjectBase {
     fields.add(new Field().withKey(key).withRefValue(ref.id));
   }
 
+  protected void set(final String key, final ArrayList<PipelineObjectBase> listref) {
+	final List<Field> subfields;
+	subfields = new ArrayList<Field>();
+	for (final PipelineObjectBase obj: listref ) { 
+		subfields.add( new Field().withKey("ref").withRefValue(obj.id) ); 
+	}
+    fields.addAll(subfields);
+  }  
+  
   protected void set(final String key, final Map<String, String> ref) {
 	final List<Field> subfields;
 	subfields = new ArrayList<Field>();

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineObjectBase.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineObjectBase.java
@@ -2,9 +2,12 @@ package edu.harvard.data.pipeline;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import com.amazonaws.services.datapipeline.model.Field;
 import com.amazonaws.services.datapipeline.model.PipelineObject;
+import com.amazonaws.services.elasticmapreduce.model.Configuration;
+
 
 import edu.harvard.data.DataConfig;
 
@@ -35,6 +38,12 @@ public class PipelineObjectBase {
     fields.add(new Field().withKey(key).withRefValue(ref.id));
   }
 
+  protected void set(final String key, final Map<String, String> ref) {
+	for (final String item : ref.values()) {
+	    fields.add(new Field().withKey(item).withStringValue( ref.get(item)));
+	}
+  }  
+  
   public void setSuccess(final PipelineObjectBase success) {
     set("onSuccess", success);
   }

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineObjectBase.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineObjectBase.java
@@ -41,7 +41,7 @@ public class PipelineObjectBase {
 	final List<Field> subfields;
 	subfields = new ArrayList<Field>();
 	for (final PipelineObjectBase obj: listref ) { 
-		subfields.add( new Field().withKey("ref").withRefValue(obj.id) ); 
+		subfields.add( new Field().withKey(key).withRefValue(obj.id) ); 
 	}
     fields.addAll(subfields);
   }  

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineObjectBase.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineObjectBase.java
@@ -39,7 +39,7 @@ public class PipelineObjectBase {
   }
 
   protected void set(final String key, final Map<String, String> ref) {
-	for (final String item : ref.values()) {
+	for (final String item : ref.keySet()) {
 	    fields.add(new Field().withKey(item).withStringValue( ref.get(item)));
 	}
   }  

--- a/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineObjectBase.java
+++ b/java/data_client/src/main/java/edu/harvard/data/pipeline/PipelineObjectBase.java
@@ -45,7 +45,11 @@ public class PipelineObjectBase {
 	    subfields.add(new Field().withKey(item).withStringValue( ref.get(item)));
 	}
 	fields.add(new Field().withKey(key).withStringValue(subfields.toString()));
-  }  
+  }
+
+  protected void set(final String key, final List<Map<String, String>> ref) {
+	fields.add(new Field().withKey(key).withStringValue(ref.toString()));
+  }
   
   public void setSuccess(final PipelineObjectBase success) {
     set("onSuccess", success);

--- a/java/data_client/src/main/java/edu/harvard/data/schema/DataSchemaTable.java
+++ b/java/data_client/src/main/java/edu/harvard/data/schema/DataSchemaTable.java
@@ -1,5 +1,6 @@
 package edu.harvard.data.schema;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -21,6 +22,13 @@ public abstract class DataSchemaTable {
 
   public abstract DataSchemaTable copy();
 
+  public List<String> getListofColumns() {
+	  final List<String> listOfColumns = new ArrayList<String>();
+	  for (final DataSchemaColumn column : getColumns()) {
+	      listOfColumns.add(column.getName());
+	  }
+	  return listOfColumns;
+  }
 
   public abstract String getLikeTable();
 

--- a/schema/canvas/phase0_schema_overrides.json
+++ b/schema/canvas/phase0_schema_overrides.json
@@ -13,7 +13,7 @@
         }
       ]
     },
-    "conference_participant_type": {
+    "conference_participant_dim": {
       "columns" : [
         {
           "name" : "participation_type",


### PR DESCRIPTION
Integrated new feature to track incremental full text variables persistently on S3 when 'delta' partial table update is specified in Phase0 for a given data source:
* Enable EMR 5.8.0 test configuration to enable support for Hive 2.3.1
* Added new fulltext format Data Configuration parameter
* Added new Canvas Rest Tab de-limited internal processing format
* Code generator updated
  * Create Hive table generator support transactional create tables for Merge tables
  * Full Text generator supports Merge into with current + new data
  * S3 to redshift load modified to add null terminator for full text variables